### PR TITLE
Fix lodestone ID lookup failing when search returns multiple entries

### DIFF
--- a/AcquisitionDate/Parser/Elements/LodestoneIDParser.cs
+++ b/AcquisitionDate/Parser/Elements/LodestoneIDParser.cs
@@ -4,6 +4,7 @@ using AcquisitionDate.Parser.Structs;
 using AcquisitionDate.Services.Interfaces;
 using HtmlAgilityPack;
 using System;
+using System.Collections.Generic;
 using System.Web;
 
 namespace AcquisitionDate.Parser.Elements;
@@ -26,85 +27,56 @@ internal class LodestoneIDParser : IAcquistionParserElement<LodestoneParseData>
             return;
         }
 
-        HtmlNode? entryNode = HtmlParserHelper.GetNode(listNode, "entry");
-        if (entryNode == null)
+        List<HtmlNode> entryNodes = HtmlParserHelper.GetNodes(listNode, "entry");
+        if (entryNodes.Count == 0)
         {
             onFailure?.Invoke(new Exception("entry is NOT found!"));
             return;
         }
 
-        string? imageURL = null;
-
-        HtmlNode? cNode = HtmlParserHelper.GetNode(listNode, "entry__chara__face");
-        if (cNode == null)
+        foreach (HtmlNode entryNode in entryNodes)
         {
-            onFailure?.Invoke(new Exception("cNode is NOT found!"));
-            return;
-        }
+            string? imageURL = null;
 
-        if (cNode.ChildNodes.Count != 0)
-        {
-            HtmlNode img = cNode.ChildNodes[0];
-            if (img != null)
-            { 
-                imageURL = img.GetAttributeValue("src", string.Empty);
+            HtmlNode? cNode = HtmlParserHelper.GetNode(entryNode, "entry__chara__face");
+            if (cNode == null) continue;
+
+            if (cNode.ChildNodes.Count != 0)
+            {
+                HtmlNode img = cNode.ChildNodes[0];
+                if (img != null)
+                {
+                    imageURL = img.GetAttributeValue("src", string.Empty);
+                }
             }
+
+            if (imageURL == null) continue;
+
+            HtmlNode? nameNode = HtmlParserHelper.GetNode(entryNode, "entry__name");
+            if (nameNode == null) continue;
+
+            string userName = HttpUtility.HtmlDecode(nameNode.InnerText);
+
+            HtmlNode? worldNode = HtmlParserHelper.GetNode(entryNode, "entry__world");
+            if (worldNode == null) continue;
+
+            string[] splitArr = worldNode.InnerText.Split(' ');
+            if (splitArr.Length != 2) continue;
+
+            string worldName = splitArr[0];
+
+            uint? worldID = Sheets.GetWorldID(worldName);
+            if (worldID == null) continue;
+
+            HtmlNode? linkNode = HtmlParserHelper.GetNode(entryNode, "entry__link");
+            if (linkNode == null) continue;
+
+            string IDvalue = linkNode.GetAttributeValue("href", string.Empty);
+
+            uint? lodestoneID = HtmlParserHelper.GetValueFromDashedLink(IDvalue);
+            if (lodestoneID == null) continue;
+
+            onSuccess?.Invoke(new LodestoneParseData(userName, worldID.Value, lodestoneID.Value, imageURL));
         }
-
-        if (imageURL == null)
-        {
-            onFailure?.Invoke(new Exception("imageURL is NOT found!"));
-            return;
-        }
-
-        HtmlNode? nameNode = HtmlParserHelper.GetNode(entryNode, "entry__name");
-        if (nameNode == null)
-        {
-            onFailure?.Invoke(new Exception("entry__name is NOT found!"));
-            return;
-        }
-
-        string userName = HttpUtility.HtmlDecode(nameNode.InnerText);
-
-        HtmlNode? worldNode = HtmlParserHelper.GetNode(entryNode, "entry__world");
-        if (worldNode == null)
-        {
-            onFailure?.Invoke(new Exception("entry__world is NOT found!"));
-            return;
-        }
-
-        string[] splitArr = worldNode.InnerText.Split(' ');
-        if (splitArr.Length != 2)
-        {
-            onFailure?.Invoke(new Exception("splitArr length is NOT 2"));
-            return;
-        }
-
-        string worldName = splitArr[0];
-
-        uint? worldID = Sheets.GetWorldID(worldName);
-        if (worldID == null)
-        {
-            onFailure?.Invoke(new Exception("worldID was NOT found in the sheets!"));
-            return;
-        }
-
-        HtmlNode? linkNode = HtmlParserHelper.GetNode(entryNode, "entry__link");
-        if (linkNode == null)
-        {
-            onFailure?.Invoke(new Exception("entry__link is NOT found!"));
-            return;
-        }
-
-        string IDvalue = linkNode.GetAttributeValue("href", string.Empty);
-
-        uint? lodestoneID = HtmlParserHelper.GetValueFromDashedLink(IDvalue);
-        if (lodestoneID == null)
-        {
-            onFailure?.Invoke(new Exception("lodestoneID is NOT found!"));
-            return;
-        }
-
-        onSuccess?.Invoke(new LodestoneParseData(userName, worldID.Value, lodestoneID.Value, imageURL));
     }
 }

--- a/AcquisitionDate/Parser/Elements/LodestoneIDParser.cs
+++ b/AcquisitionDate/Parser/Elements/LodestoneIDParser.cs
@@ -78,5 +78,7 @@ internal class LodestoneIDParser : IAcquistionParserElement<LodestoneParseData>
 
             onSuccess?.Invoke(new LodestoneParseData(userName, worldID.Value, lodestoneID.Value, imageURL));
         }
+
+        onFailure?.Invoke(new Exception("User was not found in the search results!"));
     }
 }


### PR DESCRIPTION
When a character search returns more than one result, the parser was only reading the first entry. If that entry wasn't the right character, the ID would never be set.

Changed LodestoneIDParser to iterate all entry nodes in the search results, skipping malformed ones, and letting the existing name/world validation in OnData pick out the correct match.